### PR TITLE
Fix/improve PV compatibility

### DIFF
--- a/scripts/clockwise_sweep.js
+++ b/scripts/clockwise_sweep.js
@@ -13,6 +13,7 @@ import { Shadow, ShadowProjection } from "./geometry/Shadow.js";
 import { Point3d } from "./geometry/3d/Point3d.js";
 import { Plane } from "./geometry/3d/Plane.js";
 import { getSetting, SETTINGS } from "./settings.js";
+import { MODULES_ACTIVE } from "./const.js";
 
 /**
  * Wrap ClockwisePolygonSweep.prototype._identifyEdges
@@ -139,7 +140,7 @@ export function _computeClockwiseSweepPolygon(wrapped) {
     if ( !shadowPoints.length ) continue;
     this._elevatedvision.shadows.push(new Shadow(shadowPoints));
   }
-  if ( !this._elevatedvision.shadows.length ) return;
+  if ( !this._elevatedvision.shadows.length || MODULES_ACTIVE.PERFECT_VISION ) return;
 
   // Combine the shadows and trim to be within the LOS
   // We want one or more LOS polygons along with non-overlapping holes.

--- a/scripts/patching.js
+++ b/scripts/patching.js
@@ -30,16 +30,14 @@ import {
 import {
   refreshCanvasVisibilityPolygons,
   refreshCanvasVisibilityShader,
-  createVisionCanvasVisionMaskPV,
   _createEVMask,
   _createEVMeshVisionSource,
   _createEVMeshLightSource,
-  _createMaskVisionSourcePV,
-  _createMaskLightSourcePV,
+  _createMaskPolygons,
+  _createMaskVisionSourceShader,
+  _createMaskLightSourceShader,
   _updateLosGeometryLightSource,
-  _updateLosGeometryVisionSource,
-  _createEVMeshVisionSourcePV,
-  _createEVMeshLightSourcePV
+  _updateLosGeometryVisionSource
 
 } from "./vision.js";
 
@@ -89,7 +87,7 @@ export function registerAdditions() {
     case SHADER_SWITCH.NO_SHADER: break;
     case SHADER_SWITCH.SHADER: shaderAdditions(); break;
     case SHADER_SWITCH.PV_NO_SHADER: break;
-    case SHADER_SWITCH.PV_SHADER: shaderPVAdditions(); break;
+    case SHADER_SWITCH.PV_SHADER: break;
   }
 
 }
@@ -120,33 +118,6 @@ function shaderAdditions() {
   });
 
 }
-
-function shaderPVAdditions() {
-  Object.defineProperty(VisionSource.prototype, "_createEVMesh", {
-    value: _createEVMeshVisionSourcePV,
-    writable: true,
-    configurable: true
-  });
-
-  Object.defineProperty(LightSource.prototype, "_createEVMesh", {
-    value: _createEVMeshLightSourcePV,
-    writable: true,
-    configurable: true
-  });
-
-  Object.defineProperty(VisionSource.prototype, "_createEVMask", {
-    value: _createEVMask,
-    writable: true,
-    configurable: true
-  });
-
-  Object.defineProperty(LightSource.prototype, "_createEVMask", {
-    value: _createEVMask,
-    writable: true,
-    configurable: true
-  });
-}
-
 
 export function registerPatches() {
   const shaderAlgorithm = getSetting(SETTINGS.SHADING.ALGORITHM);
@@ -186,11 +157,12 @@ export function registerPatches() {
       libWrapper.register(MODULE_ID, "CanvasVisibility.prototype.refresh", refreshCanvasVisibilityShader, libWrapper.OVERRIDE, {perf_mode: libWrapper.PERF_FAST});
       break;
     case SHADER_SWITCH.PV_NO_SHADER:
-      libWrapper.register(MODULE_ID, "CanvasVisionMask.prototype.createVision", createVisionCanvasVisionMaskPV, libWrapper.WRAPPER, {perf_mode: libWrapper.PERF_FAST});
+      libWrapper.register(MODULE_ID, "VisionSource.prototype._createMask", _createMaskPolygons, libWrapper.WRAPPER, {perf_mode: libWrapper.PERF_FAST});
+      libWrapper.register(MODULE_ID, "LightSource.prototype._createMask", _createMaskPolygons, libWrapper.WRAPPER, {perf_mode: libWrapper.PERF_FAST});
       break;
     case SHADER_SWITCH.PV_SHADER:
-      libWrapper.register(MODULE_ID, "VisionSource.prototype._createMask", _createMaskVisionSourcePV, libWrapper.OVERRIDE, {perf_mode: libWrapper.PERF_FAST});
-      libWrapper.register(MODULE_ID, "LightSource.prototype._createMask", _createMaskLightSourcePV, libWrapper.MIXED, {perf_mode: libWrapper.PERF_FAST});
+      libWrapper.register(MODULE_ID, "VisionSource.prototype._createMask", _createMaskVisionSourceShader, libWrapper.WRAPPER, {perf_mode: libWrapper.PERF_FAST});
+      libWrapper.register(MODULE_ID, "LightSource.prototype._createMask", _createMaskLightSourceShader, libWrapper.WRAPPER, {perf_mode: libWrapper.PERF_FAST});
       break;
   }
 

--- a/scripts/util.js
+++ b/scripts/util.js
@@ -111,21 +111,6 @@ export function drawPolygonWithHoles(polygonArray, {
   graphics.endFill();
 }
 
-export function drawPolygonWithHolesPV(polygonArray, {
-  graphics,
-  fillColor = 0xFFFFFF,
-  alpha = 1.0 } = {}) {
-
-  for ( const poly of polygonArray ) {
-    const g1 = new PIXI.LegacyGraphics();
-    graphics.addChild(g1);
-    g1.beginFill(fillColor, alpha).drawShape(poly).endFill();
-    g1._stencilHole = poly.isHole;
-  }
-  return graphics;
-}
-
-
 /**
  * From https://stackoverflow.com/questions/14446511/most-efficient-method-to-groupby-on-an-array-of-objects
  * Takes an Array<V>, and a grouping function,


### PR DESCRIPTION
I cleaned up the shaders: the `texture`/`textureMatrix`/... stuff is not needed, because global light sources (lighting regions) don't cast shadows and only global lights defined by roof tiles have textures.

*Polygon* shadows should work as intended now: shadows are applied to the mask mesh. PV doesn't need `combinedShadows` and `_createEVMesh`/`_createEVMask`.

Also I discovered a bug in my `StencilMask`: missing `renderer.batch.flush()` before changing `gl.stencilOp`/`gl.stencilFunc` and therefore wasn't working with batch-rendered objects like graphics. Fixed in PV 4.1.12.