### PR TITLE
Fix error on prone when shading none, add Fill by Pixel brush

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,11 @@ Switch to the elevation layer in the controls to modify the elevation data in a 
 
 ## Setting elevation
 
-Currently three tools are provided to modify elevation in a scene.
+Currently four tools are provided to modify elevation in a scene.
 
  - Fill by grid. Click a spot on the scene to set the elevation for that grid space.
+
+ - Fill by pixel. Paint elevation using a resizable circular brush. Press and hold the **[** or **]** key to decrease or increase the brush size, respectively. Hold the shift key while pressing to resize the brush faster.
 
  - Fill by line-of-sight. Click a spot, and all portions of the map will be set to that elevation that have line of sight to that spot. This uses the same algorithm as token vision, so it is the equivalent of a token's 360º vision from that spot, assuming global illumination.
 

--- a/languages/en.json
+++ b/languages/en.json
@@ -33,6 +33,9 @@
   "elevatedvision.settings.add-fly-button.name": "Add Token Fly control",
   "elevatedvision.settings.add-fly-button.hint": "Add a control to the token toolbar that can be enabled or disabled to tell Elevated Vision when a token should be considered capable of flight. When the control is enabled, automatic token elevation will keep tokens above the ground when moved off a terrain or tile cliff greater than the token height.",
 
+  "elevatedvision.settings.brush-size.name": "Fill by Pixel Brush Size",
+  "elevatedvision.settings.brush-size.hint": "Set the size of the Fill by Pixel brush.",
+
   "elevatedvision.settings.color-min.name": "Elevation Minimum Color",
   "elevatedvision.settings.color-min.hint": "Set the color used to display the minimum elevation (above the scene minimum) on the elevation layer.",
   "elevatedvision.settings.color-max.name": "Elevation Maximum Color",

--- a/scripts/ElevationLayer.js
+++ b/scripts/ElevationLayer.js
@@ -177,12 +177,13 @@ export class ElevationLayer extends InteractionLayer {
     if ( !['BracketLeft', 'BracketRight'].includes(event.code) ) return;
     if ( !this.brush.visible ) return;
 
-    const size = getSetting(SETTINGS.BRUSH.SIZE)
+    const size = getSetting(SETTINGS.BRUSH.SIZE);
+    const increment = (event.shiftKey) ? 5 : 1;
 
     if (event.code === 'BracketLeft') {
-      if (size > SETTINGS.BRUSH.MIN_SIZE) setSetting(SETTINGS.BRUSH.SIZE, size - 1)
+      if (size > SETTINGS.BRUSH.MIN_SIZE) setSetting(SETTINGS.BRUSH.SIZE, size - increment);
     } else {
-      if (size < SETTINGS.BRUSH.MAX_SIZE ) setSetting(SETTINGS.BRUSH.SIZE, size + 1)
+      if (size < SETTINGS.BRUSH.MAX_SIZE ) setSetting(SETTINGS.BRUSH.SIZE, size + increment);
     }
 
     this.drawBrush({ visible: true });

--- a/scripts/ElevationLayer.js
+++ b/scripts/ElevationLayer.js
@@ -29,7 +29,7 @@ import {
 import { testWallsForIntersections } from "./ClockwiseSweepPolygon.js";
 import { SCENE_GRAPH } from "./WallTracer.js";
 import { FILOQueue } from "./FILOQueue.js";
-import { setSceneSetting, getSceneSetting, getSetting, SETTINGS } from "./settings.js";
+import { setSceneSetting, getSceneSetting, setSetting, getSetting, SETTINGS } from "./settings.js";
 import { CoordinateElevationCalculator } from "./CoordinateElevationCalculator.js";
 import { TokenElevationCalculator } from "./TokenElevationCalculator.js";
 import { TravelElevationRay } from "./TravelElevationRay.js";
@@ -95,16 +95,18 @@ export class ElevationLayer extends InteractionLayer {
    * See Ruler.prototype._onMouseMove
    */
   _onMouseMove(event) {
-    if ( !canvas.ready
-      || !canvas.elevation.active
-      || !this.elevationLabel ) return;
+    if ( !canvas.ready || !canvas.elevation.active ) return;
 
     // Get the canvas position of the mouse pointer.
     const pos = event.getLocalPosition(canvas.app.stage);
     if ( !canvas.dimensions.sceneRect.contains(pos.x, pos.y) ) {
+      this.brush.visible = false;
       this.elevationLabel.visible = false;
       return;
     }
+
+    // Update the brush preview.
+    this.drawBrush({ x: pos.x, y: pos.y, visible: true });
 
     // Update the numeric label with the elevation at this position.
     this.updateElevationLabel(pos);
@@ -124,6 +126,66 @@ export class ElevationLayer extends InteractionLayer {
     this.elevationLabel = new PreciseText(undefined, textStyle);
     this.elevationLabel.anchor = {x: 0, y: 1};
     canvas.stage.addChild(this.elevationLabel);
+  }
+
+  /**
+   * Initialize the brush.
+   */
+  initializeBrush() {
+    const brush = new PIXI.Graphics();
+    brush.visible =  false;
+    brush.x = 0;
+    brush.y = 0;
+    brush.zIndex = 10;
+
+    return brush;
+  }
+
+  /**
+   * Draw the brush.
+   */
+  drawBrush(data = {}) {
+    const canvasScale = game?.canvas?.stage?.scale?._x ?? 1.5
+    const size = getSetting(SETTINGS.BRUSH.SIZE) ?? 100
+    const lineWidth = Math.round(4 - canvasScale)
+
+    this.brush.clear();
+    this.brush.lineStyle(lineWidth)
+
+    switch (game.activeTool) {
+      case "fill-by-pixel":
+        const ellipseSize = Math.round(size / 2)
+        this.brush.drawEllipse(0, 0, ellipseSize, ellipseSize);
+        break;
+      default:
+        break;
+    }
+
+    this.brush.endFill();
+
+    this.brush.visible =  data?.visible ?? false;
+    this.brush.x = data?.x ?? canvas.mousePosition.x;
+    this.brush.y = data?.y ?? canvas.mousePosition.y;
+  }
+
+  /**
+   * Update the brush size when the [ or ] keys are pressed.
+   * Potentially replace with keybindings if/when it supports holding the key.
+   */
+  updateBrushSize(event) {
+    if ( game.activeTool !== 'fill-by-pixel' ) return;
+    if ( !['BracketLeft', 'BracketRight'].includes(event.code) ) return;
+    if ( !this.brush.visible ) return;
+
+    const size = getSetting(SETTINGS.BRUSH.SIZE)
+
+    if (event.code === 'BracketLeft') {
+      if (size > SETTINGS.BRUSH.MIN_SIZE) setSetting(SETTINGS.BRUSH.SIZE, size - 1)
+    } else {
+      if (size < SETTINGS.BRUSH.MAX_SIZE ) setSetting(SETTINGS.BRUSH.SIZE, size + 1)
+    }
+
+    this.drawBrush({ visible: true });
   }
 
   /**
@@ -487,6 +549,7 @@ export class ElevationLayer extends InteractionLayer {
 
     this.drawElevation();
     this.container.visible = true;
+    canvas.stage.addChild(this.brush);
     canvas.stage.addChild(this.elevationLabel);
     canvas.stage.addChild(this._wallDataContainer);
   }
@@ -504,6 +567,7 @@ export class ElevationLayer extends InteractionLayer {
     const wallData = this._wallDataContainer.removeChildren();
     wallData.forEach(d => d.destroy(true));
 
+    canvas.stage.removeChild(this.brush);
     canvas.stage.removeChild(this.elevationLabel);
     if ( this._requiresSave ) this.saveSceneElevationData();
     Draw.clearDrawings();
@@ -547,6 +611,10 @@ export class ElevationLayer extends InteractionLayer {
 
     this._initialized = false;
     this._clearElevationPixelCache();
+
+    // Initialize the brush
+    this.brush = this.initializeBrush();
+    document.addEventListener("keypress", (event) => { this.updateBrushSize(event) });
 
     // Initialize the texture manager for the scene.
     const sceneEVData = canvas.scene.getFlag(MODULE_ID, FLAGS.ELEVATION_IMAGE);
@@ -945,6 +1013,24 @@ export class ElevationLayer extends InteractionLayer {
     return graphics;
   }
 
+  setElevationForPixel(p, elevation = 0, { temporary = false } = {}) {
+    const shape = this._circleShape(p);
+    const graphics = this._graphicsContainer.addChild(new PIXI.Graphics());
+    const color = this.elevationColor(elevation);
+    this._updateElevationCurrentMax(elevation);
+
+    // Set width = 0 to avoid drawing a border line. The border line will use antialiasing
+    // and that causes a lighter-color border to appear outside the shape.
+    const draw = new Draw(graphics);
+    draw.shape(shape, { width: 0, fill: color});
+
+    this.renderElevation();
+
+    this._requiresSave = !temporary;
+    this.undoQueue.enqueue(graphics);
+    return graphics;
+  }
+
   /* -------------------------------------------- */
   /* NOTE: TOKEN SHAPES */
 
@@ -975,6 +1061,12 @@ export class ElevationLayer extends InteractionLayer {
     }
 
     return new PIXI.Polygon(pointsTranslated);
+  }
+
+  _circleShape(p) {
+    const brushSize = getSetting(SETTINGS.BRUSH.SIZE);
+    const r = (brushSize > 1) ? Math.round(getSetting(SETTINGS.BRUSH.SIZE) / 2) : 1;
+    return new PIXI.Circle(p.x, p.y, r);
   }
 
   /* -------------------------------------------- */
@@ -1313,7 +1405,7 @@ export class ElevationLayer extends InteractionLayer {
         this.fillLOS(o, currE);
         break;
       case "fill-by-pixel":
-        log("fill-by-pixel not yet implemented.");
+        this.setElevationForPixel(o, currE);
         break;
       case "fill-space":
         this.fill(o, currE);
@@ -1334,12 +1426,22 @@ export class ElevationLayer extends InteractionLayer {
     const currE = this.controls.currentElevation;
     log(`dragLeftStart at ${o.x}, ${o.y} with tool ${activeTool} and elevation ${currE}`, event);
 
-    if ( activeTool === "fill-by-grid" ) {
-      this.#temporaryGraphics.clear(); // Should be accomplished elsewhere already
-      const [tlx, tly] = canvas.grid.grid.getTopLeft(o.x, o.y);
-      const p = new PolygonVertex(tlx, tly);
-      const child = this.setElevationForGridSpace(o, currE, { temporary: true });
-      this.#temporaryGraphics.set(p.key, child);
+    switch ( activeTool ) {
+      case "fill-by-grid": {
+        this.#temporaryGraphics.clear(); // Should be accomplished elsewhere already
+        const [tlx, tly] = canvas.grid.grid.getTopLeft(o.x, o.y);
+        const p = new PolygonVertex(tlx, tly);
+        const child = this.setElevationForGridSpace(o, currE, { temporary: true });
+        this.#temporaryGraphics.set(p.key, child);
+      } 
+      break;
+      case "fill-by-pixel": {
+        this.#temporaryGraphics.clear(); // Should be accomplished elsewhere already
+        const p = new PolygonVertex(o.x, o.y);
+        const child = this.setElevationForPixel(p, currE, { temporary: true });
+        this.#temporaryGraphics.set(p.key, child);
+      }
+      break;
     }
   }
 
@@ -1355,14 +1457,26 @@ export class ElevationLayer extends InteractionLayer {
 
     // TO-DO: What if the user changes the elevation mid-drag? (if MouseWheel enabled)
 
-    if ( activeTool === "fill-by-grid" ) {
-      const [tlx, tly] = canvas.grid.grid.getTopLeft(d.x, d.y);
-      const p = new PolygonVertex(tlx, tly);
-      if ( !this.#temporaryGraphics.has(p.key) ) {
-        log(`dragLeftMove from ${o.x},${o.y} to ${d.x}, ${d.y} with tool ${activeTool} and elevation ${currE}`, event);
-        const child = this.setElevationForGridSpace(d, currE, { temporary: true });
-        this.#temporaryGraphics.set(p.key, child);
+    switch ( activeTool ) {
+      case "fill-by-grid": {
+        const [tlx, tly] = canvas.grid.grid.getTopLeft(d.x, d.y);
+        const p = new PolygonVertex(tlx, tly);
+        if ( !this.#temporaryGraphics.has(p.key) ) {
+          log(`dragLeftMove from ${o.x},${o.y} to ${d.x}, ${d.y} with tool ${activeTool} and elevation ${currE}`, event);
+          const child = this.setElevationForGridSpace(d, currE, { temporary: true });
+          this.#temporaryGraphics.set(p.key, child);
+        }
       }
+      break;
+      case "fill-by-pixel": {
+        const p = new PolygonVertex(d.x, d.y);
+        if ( !this.#temporaryGraphics.has(p.key) ) {
+          log(`dragLeftMove from ${o.x},${o.y} to ${d.x}, ${d.y} with tool ${activeTool} and elevation ${currE}`, event);
+          const child = this.setElevationForPixel(p, currE, { temporary: true });
+          this.#temporaryGraphics.set(p.key, child);
+        }
+      }
+      break;
     }
   }
 

--- a/scripts/Token.js
+++ b/scripts/Token.js
@@ -286,6 +286,7 @@ PATCHES_Token.BASIC.METHODS = { getTopLeft };
  * This will cause shadows to change based on the changed token height.
  */
 function createOrRemoveActiveEffectHook(effect, _opts, _userId) {
+  if ( getSceneSetting(SETTINGS.SHADING.ALGORITHM) === SETTINGS.SHADING.TYPES.NONE ) return;
   if ( !effect.statuses.has(CONFIG.GeometryLib.proneStatusId) ) return;
 
   const tokens = effect.parent?.getActiveTokens();

--- a/scripts/controls.js
+++ b/scripts/controls.js
@@ -23,7 +23,10 @@ import { ElevationLayerToolBar } from "./ElevationLayerToolBar.js";
 import { MODULE_ID } from "./const.js";
 
 Hooks.on("getSceneControlButtons", addElevationLayerSceneControls);
-Hooks.on("renderSceneControls", addElevationLayerSubControls);
+Hooks.on("renderSceneControls", (controls) => {
+  addElevationLayerSubControls(controls)
+  drawBrush(controls);
+});
 Hooks.on("renderTerrainLayerToolBar", renderElevationLayerSubControls);
 Hooks.on("getSceneControlButtons", addDirectionalLightingControl);
 
@@ -63,14 +66,11 @@ function addElevationLayerSceneControls(controls) {
         title: game.i18n.localize(`${MODULE_ID}.controls.fill-by-los.name`),
         icon: "fas fa-eye"
       },
-
-      /* TO-DO: How feasible would be a "painting" option with circle or square brush?
       {
         name: "fill-by-pixel",
         title: "Fill by Pixel",
         icon: "fas fa-paintbrush-fine"
       },
-      */
       {
         name: "fill-space",
         title: game.i18n.localize(`${MODULE_ID}.controls.fill-space.name`),
@@ -138,6 +138,17 @@ function addElevationLayerSubControls(controls) {
   } else {
     if ( !canvas.elevation.toolbar ) return;
     canvas.elevation.toolbar.close();
+  }
+}
+
+function drawBrush(controls) {
+  if ( !canvas.elevation ) return;
+  switch (controls.tool) {
+    case 'fill-by-pixel': 
+      canvas.elevation.drawBrush();
+      break;
+    default:
+      break;
   }
 }
 

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -23,6 +23,13 @@ export const SETTINGS = {
     }
   },
 
+  BRUSH: {
+    SIZE: 'brush-size',
+    DEFAULT_SIZE: 100,
+    MAX_SIZE: 500,
+    MIN_SIZE: 1
+  },
+
   COLOR: {
     MIN: "color-min",
     MAX: "color-max",
@@ -86,7 +93,6 @@ export function defaultSceneSetting(value) {
   }
 }
 
-
 export function registerSettings() {
   log("Registering elevated vision settings");
 
@@ -136,6 +142,21 @@ export function registerSettings() {
       step: 1
     },
     default: 0,
+    requiresReload: false,
+    type: Number
+  });
+
+  game.settings.register(MODULE_ID, SETTINGS.BRUSH.SIZE, {
+    name: game.i18n.localize(`${MODULE_ID}.settings.${SETTINGS.BRUSH.SIZE}.name`),
+    hint: game.i18n.localize(`${MODULE_ID}.settings.${SETTINGS.BRUSH.SIZE}.hint`),
+    scope: "world",
+    config: true,
+    range: {
+      min: 1,
+      step: 1,
+      max: SETTINGS.BRUSH.MAX_SIZE
+    },
+    default: SETTINGS.BRUSH.DEFAULT_SIZE,
     requiresReload: false,
     type: Number
   });


### PR DESCRIPTION
Fixes this error when toggling the Prone status effect while the scene shading is set to None:
![image](https://github.com/caewok/fvtt-elevated-vision/assets/105953297/e963e9e1-5280-43ad-b421-8cadf0053e4c)
