### PR TITLE
Fix error when ColorPicker module is active

### DIFF
--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -208,27 +208,35 @@ export class Settings extends ModuleSettingsAbstract {
     });
 
     if ( game.modules.get("color-picker")?.active ) {
-      ColorPicker.register(KEYS.COLOR.MIN, {
-        name: localize(`${KEYS.COLOR.MIN}.name`),
-        hint: localize(`${KEYS.COLOR.MIN}.hint`),
-        scope: "world",
-        config: true,
-        default: KEYS.COLOR.DEFAULT_MIN,
-        format: "hexa",
-        mode: "HVS",
-        onChange: value => canvas.elevation._elevationColorsMesh.shader.updateMinColor(value)
-      });
+      ColorPicker.register(
+        MODULE_ID,
+        KEYS.COLOR.MIN, 
+        {
+          name: localize(`${KEYS.COLOR.MIN}.name`),
+          hint: localize(`${KEYS.COLOR.MIN}.hint`),
+          scope: "world",
+          config: true,
+          default: KEYS.COLOR.DEFAULT_MIN,
+          format: "hexa",
+          mode: "HVS",
+          onChange: value => canvas.elevation._elevationColorsMesh.shader.updateMinColor(value)
+        }
+      );
 
-      ColorPicker.register(KEYS.COLOR.MAX, {
-        name: localize(`${KEYS.COLOR.MAX}.name`),
-        hint: localize(`${KEYS.COLOR.MAX}.hint`),
-        scope: "world",
-        config: true,
-        default: KEYS.COLOR.DEFAULT_MAX,
-        format: "hexa",
-        mode: "HVS",
-        onChange: value => canvas.elevation._elevationColorsMesh.shader.updateMaxColor(value)
-      });
+      ColorPicker.register(
+        MODULE_ID,
+        KEYS.COLOR.MAX,
+        {
+          name: localize(`${KEYS.COLOR.MAX}.name`),
+          hint: localize(`${KEYS.COLOR.MAX}.hint`),
+          scope: "world",
+          config: true,
+          default: KEYS.COLOR.DEFAULT_MAX,
+          format: "hexa",
+          mode: "HVS",
+          onChange: value => canvas.elevation._elevationColorsMesh.shader.updateMaxColor(value)
+        }
+      );
 
     } else {
       register(KEYS.COLOR.MIN, {


### PR DESCRIPTION
Fixes an error when the ColorPicker module is active and Elevated Vision registers the `color-min` and `color-max` settings. This was due to `ColorPicker.register` requiring the module's ID as the first parameter.